### PR TITLE
Approach to killing stunner process does not work on macOS. 

### DIFF
--- a/stunredis.sh
+++ b/stunredis.sh
@@ -60,13 +60,11 @@ stunnelconf+=$"connect=$hostport\n"
 
 echo -e $stunnelconf | stunnel -fd 0 &
 
-# Grab the pid
-stunnelpid=$!
 # Sleep a moment to let the connection establish
 sleep 1 
 # Now call redis-cli for the user to interact with
 redis-cli -p $LOCALPORT -a ${pass}
 # Once they leave that, kill the stunnel
-kill $stunnelpid
+ps -ef | grep stunnel | grep -v grep | awk '{print $2}' | xargs kill
 
 


### PR DESCRIPTION
Changed approach to killing stunnel process as it was not working on ……macOS (the PID it tries to kill does not exist).