### PR TITLE
Harden stunredis.sh by not using a local TCP port

### DIFF
--- a/stunredis.sh
+++ b/stunredis.sh
@@ -17,7 +17,6 @@
 #    limitations under the License.
 
 DATABASE_URL=$1
-LOCALPORT=${2:-6830}
 
 # This is the location of the validation chain file
 lechain=./lechain.pem
@@ -48,7 +47,7 @@ stunnelconf=""
 stunnelconf+=$"foreground=yes\n" 
 stunnelconf+=$"[redis-cli]\n"
 stunnelconf+=$"client=yes\n"
-stunnelconf+=$"accept=127.0.0.1:$LOCALPORT\n"
+stunnelconf+=$"accept=${HOME}/${host}.${hostport}.${BASHPID}.sock\n"
 stunnelconf+=$"verifyChain=yes\n"
 stunnelconf+=$"checkHost=$host\n"
 stunnelconf+=$"CAfile=$lechain\n"
@@ -65,7 +64,7 @@ stunnelpid=$!
 # Sleep a moment to let the connection establish
 sleep 1 
 # Now call redis-cli for the user to interact with
-redis-cli -p $LOCALPORT -a ${pass}
+redis-cli -s ${HOME}/${host}.${hostport}.${BASHPID}.sock
 # Once they leave that, kill the stunnel
 kill $stunnelpid
 

--- a/stunredis.sh
+++ b/stunredis.sh
@@ -17,6 +17,7 @@
 #    limitations under the License.
 
 DATABASE_URL=$1
+REMOTEPORT=${2:-6830}
 
 # This is the location of the validation chain file
 lechain=./lechain.pem
@@ -47,7 +48,7 @@ stunnelconf=""
 stunnelconf+=$"foreground=yes\n" 
 stunnelconf+=$"[redis-cli]\n"
 stunnelconf+=$"client=yes\n"
-stunnelconf+=$"accept=${HOME}/${host}.${hostport}.${BASHPID}.sock\n"
+stunnelconf+=$"accept=${HOME}/${host}.${REMOTEPORT}.${BASHPID}.sock\n"
 stunnelconf+=$"verifyChain=yes\n"
 stunnelconf+=$"checkHost=$host\n"
 stunnelconf+=$"CAfile=$lechain\n"
@@ -64,7 +65,7 @@ stunnelpid=$!
 # Sleep a moment to let the connection establish
 sleep 1 
 # Now call redis-cli for the user to interact with
-redis-cli -s ${HOME}/${host}.${hostport}.${BASHPID}.sock
+redis-cli -s ${HOME}/${host}.${REMOTEPORT}.${BASHPID}.sock
 # Once they leave that, kill the stunnel
 kill $stunnelpid
 

--- a/stunredis.sh
+++ b/stunredis.sh
@@ -32,8 +32,10 @@ userpass="`echo $url | grep @ | cut -d@ -f1`"
 pass=`echo $userpass | grep : | cut -d: -f2`
 if [ -n "$pass" ]; then
     user=`echo $userpass | grep : | cut -d: -f1`
+    AUTH=" -a ${pass}"
 else
     user=$userpass
+    AUTH=""
 fi
 hostport=`echo $url | sed -e s,$userpass@,,g | cut -d/ -f1`
 port=`echo $hostport | grep : | cut -d: -f2`
@@ -65,8 +67,6 @@ stunnelpid=$!
 # Sleep a moment to let the connection establish
 sleep 1 
 # Now call redis-cli for the user to interact with
-redis-cli -s ${HOME}/${host}.${REMOTEPORT}.${BASHPID}.sock
+redis-cli ${AUTH} -s ${HOME}/${host}.${REMOTEPORT}.${BASHPID}.sock
 # Once they leave that, kill the stunnel
 kill $stunnelpid
-
-


### PR DESCRIPTION
Your script is very helpful. However, it is not secure in a multiuser host. The script opens up a TCP port bound to the loopback device, which IMHO means that (at least without some ip[6]tables hardening) anyone on localhost can use the TCP port without having the cert and/or private key (in case of two-way trust TLS, which we use. `cert` and `key` in `stunnel`.). This might not seem relevant to (for example) a vagrant dev VM, but it's easy to avoid: just use a unix domain socket. `stunnel` as well as `redis-cli` supports it. **As a bonus:** the unix domain socket performs better as well.
Sidenote: `stunnel` removes the socket file automatically, with a clean exit. Please judge yourself if a more resilient cleanup is needed (I don't think so, but could be wrong).